### PR TITLE
Added $.response.contentType for Better Rendering

### DIFF
--- a/src/apps/xs/consumption/iotmmsxs/iotservice.xsjs
+++ b/src/apps/xs/consumption/iotmmsxs/iotservice.xsjs
@@ -14,4 +14,5 @@ for(var i = 0; i < oResultSet.length; i++) {
 oConnection.close();
 
 $.response.status = $.net.http.OK;
+$.response.contentType = "text/plain";
 $.response.setBody(sBody);


### PR DESCRIPTION
`\n` doesn't render properly on all browsers unless Content Type is specified. Else, `<br>` is needed for HTML.