### PR TITLE
 replace javax.xml.bind.DatatypeConverter with java.util.Base64

### DIFF
--- a/cf/samples/java-samples/README.md
+++ b/cf/samples/java-samples/README.md
@@ -2,6 +2,11 @@
 
 Contains various Java samples which illustrate the API usage across different use cases.
 
+### Prerequisites
+
+* Maven
+* JDK 1.8 or higher
+
 >IMPORTANT: After the very first import from GitHub, ensure to run `mvn clean install` for the current reactor project in order to build [commons](./commons) - a Maven module containing generic logic which is used by the provided samples.
 
 ## Upstream. Sending measures from the device.

--- a/cf/samples/java-samples/commons/src/main/java/commons/connectivity/HttpClient.java
+++ b/cf/samples/java-samples/commons/src/main/java/commons/connectivity/HttpClient.java
@@ -8,10 +8,10 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.Base64;
 
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSocketFactory;
-import javax.xml.bind.DatatypeConverter;
 
 import com.google.gson.JsonSyntaxException;
 
@@ -54,8 +54,9 @@ extends AbstractClient {
 		connection = openConnection(destination);
 
 		if (user != null && password != null) {
-			String base64 = DatatypeConverter
-				.printBase64Binary((user + ":" + password).getBytes(ENCODING));
+			byte[] encodedBytes = Base64.getMimeEncoder()
+				.encode((user + ":" + password).getBytes(ENCODING));
+			String base64 = new String(encodedBytes, ENCODING);
 			connection.setRequestProperty("Authorization", "Basic " + base64);
 		}
 		else if (sslSocketFactory != null && connection instanceof HttpsURLConnection) {

--- a/cf/samples/java-samples/commons/src/main/java/commons/utils/SecurityUtil.java
+++ b/cf/samples/java-samples/commons/src/main/java/commons/utils/SecurityUtil.java
@@ -16,6 +16,7 @@ import java.security.PrivateKey;
 import java.security.cert.Certificate;
 import java.security.cert.CertificateFactory;
 import java.security.spec.KeySpec;
+import java.util.Base64;
 
 import javax.crypto.Cipher;
 import javax.crypto.EncryptedPrivateKeyInfo;
@@ -27,8 +28,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocketFactory;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
-import javax.xml.bind.DatatypeConverter;
 
+import commons.connectivity.AbstractClient;
 import commons.model.Authentication;
 import commons.model.Device;
 
@@ -76,7 +77,7 @@ public class SecurityUtil {
 		PrivateKey privateKey = decryptPrivateKey(encryptedPrivateKey, secret);
 
 		ByteArrayInputStream is = new ByteArrayInputStream(
-			DatatypeConverter.parseBase64Binary(pem));
+			Base64.getMimeDecoder().decode(pem.getBytes(AbstractClient.ENCODING)));
 
 		Certificate certificate;
 		try {
@@ -133,7 +134,8 @@ public class SecurityUtil {
 	private static PrivateKey decryptPrivateKey(String encryptedPrivateKey, String secret)
 	throws GeneralSecurityException, IOException {
 
-		byte[] encodedPrivateKey = DatatypeConverter.parseBase64Binary(encryptedPrivateKey);
+		byte[] encodedPrivateKey = Base64.getMimeDecoder()
+			.decode(encryptedPrivateKey.getBytes(AbstractClient.ENCODING));
 
 		EncryptedPrivateKeyInfo encryptPKInfo = new EncryptedPrivateKeyInfo(encodedPrivateKey);
 		Cipher cipher = Cipher.getInstance(CIPHER_ALGORITHM);

--- a/cf/samples/java-samples/pom.xml
+++ b/cf/samples/java-samples/pom.xml
@@ -43,8 +43,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.5.1</version>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 


### PR DESCRIPTION
- replace javax.xml.bind.DatatypeConverter with java.util.Base64 (to make it work with Java 9)
- enforce JDK 1.8 as minimum