### PR TITLE
allow manual setting of pem and secret

### DIFF
--- a/cf/samples/java-samples/commons/src/main/java/commons/model/Authentication.java
+++ b/cf/samples/java-samples/commons/src/main/java/commons/model/Authentication.java
@@ -8,6 +8,11 @@ public class Authentication {
 
 	private String password;
 
+	public Authentication(String pem, String secret) {
+		this.pem = pem;
+		this.secret = secret;
+	}
+
 	public String getSecret() {
 		return secret;
 	}
@@ -15,9 +20,17 @@ public class Authentication {
 	public String getPem() {
 		return pem;
 	}
+	
+	public void setPem(String pem) {
+		this.pem = pem;
+	}
 
 	public String getPassword() {
 		return password;
 	}
 
+	public void setSecret(String secret) {
+		this.secret = secret;
+	}
+	
 }


### PR DESCRIPTION
allow manual setting of pem and secret.
e.g. when using the provided sample in a standalone application, where the device is already onboarded and we want to authenticate using the downloaded certificate without the need to provide the tenant user/pwd.